### PR TITLE
align installation instructions

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -25,6 +25,8 @@ To install and run the client, just type...
 
 .. code-block:: shell
 
+   git clone https://github.com/letsencrypt/letsencrypt
+   cd letsencrypt
    ./letsencrypt-auto
 
 .. hint:: During the beta phase, Let's Encrypt enforces strict rate limits on


### PR DESCRIPTION
align installation instructions to "getting started" and other user guides.
You shouldn't take for granted that users coming to the installation instructions have read other pages elsewhere on the website. 
All the needed steps should be shown here too to have a functioning installation.
